### PR TITLE
allow for indeterminate query strings

### DIFF
--- a/env/node.js
+++ b/env/node.js
@@ -21,9 +21,9 @@ var baseRedirects = (req, res, next) => {
   var redirect = false;
   var url = req.url;
 
-  if (url !== '/' && url.indexOf('/?') > -1) {
+  if (url.indexOf('/?') > -1 && url.indexOf('/?') !== 0) {
     redirect = true;
-    url = url.substring(0, url.indexOf('/?'));
+    url = url.replace('/?', '?');
   }
 
   if (url.indexOf('2013/blog') > -1) {


### PR DESCRIPTION
Google ads for the home page skookum.com add a query string with /?abc=abc, previously were removing /? due to 504 errors from old blog posts