### PR TITLE
redirect to 404 page if invalid blog or case study slug

### DIFF
--- a/handlers/BlogArticle/index.js
+++ b/handlers/BlogArticle/index.js
@@ -7,6 +7,7 @@ import * as fmt from 'fmt';
 import api from 'api';
 import Hero from 'Hero';
 import ShareLinks from 'ShareLinks';
+import NotFound from '../../handlers/NotFound';
 import DocMeta from 'react-doc-meta';
 
 var {PropTypes} = React;
@@ -26,9 +27,10 @@ function getDefaultImage(tags: Array): String {
   return IMAGES.all;
 }
 
-
 class BlogArticle extends React.Component {
+
   render(): ?ReactElement {
+    if (this.props.article === 'notfound') { return <NotFound />; }
     var {
       title,
       tags,
@@ -113,7 +115,7 @@ BlogArticle.displayName = 'BlogArticle';
 export default Resolver.createContainer(BlogArticle, {
   resolve: {
     article(props) {
-      return api(`contentful/${props.params.slug}`);
+      return api(`contentful/${props.params.slug}`).catch(err => 'notfound');
     },
   },
 });

--- a/handlers/CaseStudyArticle/index.js
+++ b/handlers/CaseStudyArticle/index.js
@@ -4,15 +4,16 @@ import React from 'react';
 import markdown from 'markdown';
 import {Resolver} from 'react-resolver';
 import * as fmt from 'fmt';
-
 import api from 'api';
 import Hero from 'Hero';
 import ShareLinks from 'ShareLinks';
+import NotFound from '../../handlers/NotFound';
 
 var {PropTypes} = React;
 
 class CaseStudyArticle extends React.Component {
   render(): ?ReactElement {
+    if (this.props.article === 'notfound') { return <NotFound />; }
     var {
       title,
       tags,
@@ -47,7 +48,7 @@ CaseStudyArticle.displayName = 'CaseStudyArticle';
 export default Resolver.createContainer(CaseStudyArticle, {
   resolve: {
     article(props) {
-      return api(`contentful/${props.params.slug}`);
+      return api(`contentful/${props.params.slug}`).catch(err => 'notfound');
     },
   },
 });

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,10 +1,11 @@
 /** @flow */
+
 var status: Promise = (response) => {
   if (response.status >= 200 && response.status < 300) {
     return response;
   }
 
-  return response.json().then(data => {
+  return response.json().catch(data => {
     throw new Error(JSON.stringify(data));
   });
 };


### PR DESCRIPTION
this is essentially a soft 404 redirect and a temporary solution until we update react-router to it's newest version. 